### PR TITLE
fix: Update Dart SDK version constraints (`">=3.2.0 <3.5.0"`) (v0.0.3) (#4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.3
+
+- Add Dart SDK version top constraint (`">=3.2.0 <3.5.0"`)
+
 ## 0.0.2
 
 - Added docs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.0.3
 
 - Add Dart SDK version top constraint (`">=3.2.0 <3.5.0"`)
+- Change `package:analyzer` version constraints (`">=6.0.0 <6.8.0"`)
 
 ## 0.0.2
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.2
 repository: https://github.com/MOST-Innovation-Labs/most_custom_lints
 
 environment:
-  sdk: ^3.2.0
+  sdk: ">=3.2.0 <3.5.0"
 
 dependencies:
   meta: ^1.10.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   custom_lint: ^0.6.0
   custom_lint_builder: ^0.6.0
 
-  analyzer: ^6.0.0
+  analyzer: ">=6.0.0 <6.8.0"
   analyzer_plugin: ^0.11.0
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: most_custom_lints
 description: Lints rules and corresponding annotations used by Dart/Flutter team at MOST.
-version: 0.0.2
+version: 0.0.3
 repository: https://github.com/MOST-Innovation-Labs/most_custom_lints
 
 environment:


### PR DESCRIPTION
Because of the most recent package:analyzer@6.8.0 and dart@3.5.0, we need 2 releases: one for the old Dart SDK constraints, and the other - for the new Dart SDK version.