### PR TITLE
fix: Update Dart SDK version constraints (`">=3.5.0 <3.6.0"`) (v0.0.4) (#5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.3
+
+- Add Dart SDK version top constraint (`">=3.2.0 <3.5.0"`)
+
 ## 0.0.2
 
 - Added docs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.0.4
+
+- Change Dart SDK version constraints (`">=3.5.0 <3.6.0"`)
+- Change `package:analyzer` version constraints (`">=6.8.0 <7.0.0"`)
+
 ## 0.0.3
 
 - Add Dart SDK version top constraint (`">=3.2.0 <3.5.0"`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.0.3
 
 - Add Dart SDK version top constraint (`">=3.2.0 <3.5.0"`)
+- Change `package:analyzer` version constraints (`">=6.0.0 <6.8.0"`)
 
 ## 0.0.2
 

--- a/lib/src/dart_lint_rules/deprecated_from_expired_lint_rule.dart
+++ b/lib/src/dart_lint_rules/deprecated_from_expired_lint_rule.dart
@@ -1,6 +1,6 @@
 import 'package:analyzer/dart/constant/value.dart';
 import 'package:analyzer/dart/element/element.dart';
-import 'package:analyzer/error/error.dart';
+import 'package:analyzer/error/error.dart' show ErrorSeverity;
 import 'package:analyzer/error/listener.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 import 'package:most_custom_lints/src/utils/type_utils.dart';
@@ -37,17 +37,18 @@ class DeprecatedFromExpiredLintRule extends DartLintRule {
         final deprecationDate = _parseDeprecationDate(deprecatedFromObject);
 
         if (deprecationDate == null) {
-          reporter.reportErrorForNode(
+          reporter.atNode(
+            node,
             LintCode(
               name: code.name,
               problemMessage: 'Invalid deprecation date.',
               errorSeverity: ErrorSeverity.ERROR,
             ),
-            node,
           );
         } else if (deprecationDate.isBefore(DateTime.now())) {
           final deprecationDateText = _formatDeprecationDate(deprecationDate);
-          reporter.reportErrorForNode(
+          reporter.atNode(
+            node,
             LintCode(
               name: code.name,
               problemMessage: 'Deprecated on '
@@ -56,11 +57,11 @@ class DeprecatedFromExpiredLintRule extends DartLintRule {
                   '$message',
               errorSeverity: ErrorSeverity.WARNING,
             ),
-            node,
           );
         } else {
           final deprecationDateText = _formatDeprecationDate(deprecationDate);
-          reporter.reportErrorForNode(
+          reporter.atNode(
+            node,
             LintCode(
               name: code.name,
               problemMessage: 'To be deprecated starting from '
@@ -68,7 +69,6 @@ class DeprecatedFromExpiredLintRule extends DartLintRule {
                   '$message',
               errorSeverity: ErrorSeverity.INFO,
             ),
-            node,
           );
         }
       }

--- a/lib/src/dart_lint_rules/use_deprecated_from_lint_rule.dart
+++ b/lib/src/dart_lint_rules/use_deprecated_from_lint_rule.dart
@@ -1,4 +1,4 @@
-import 'package:analyzer/error/error.dart';
+import 'package:analyzer/error/error.dart' show ErrorSeverity;
 import 'package:analyzer/error/listener.dart';
 import 'package:custom_lint_builder/custom_lint_builder.dart';
 import 'package:most_custom_lints/src/utils/type_utils.dart';
@@ -27,13 +27,13 @@ class UseDeprecatedFromLintRule extends DartLintRule {
           annotations.where((e) => e.hasType('Deprecated'));
 
       if (deprecatedUsages.isNotEmpty) {
-        reporter.reportErrorForNode(
+        reporter.atNode(
+          node,
           LintCode(
             name: code.name,
             problemMessage: code.problemMessage,
             errorSeverity: ErrorSeverity.INFO,
           ),
-          node,
         );
       }
     });

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.2
 repository: https://github.com/MOST-Innovation-Labs/most_custom_lints
 
 environment:
-  sdk: ^3.2.0
+  sdk: ">=3.2.0 <3.5.0"
 
 dependencies:
   meta: ^1.10.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   custom_lint: ^0.6.0
   custom_lint_builder: ^0.6.0
 
-  analyzer: ^6.0.0
+  analyzer: ">=6.0.0 <6.8.0"
   analyzer_plugin: ^0.11.0
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.3
 repository: https://github.com/MOST-Innovation-Labs/most_custom_lints
 
 environment:
-  sdk: ">=3.2.0 <3.5.0"
+  sdk: ">=3.5.0 <3.6.0"
 
 dependencies:
   meta: ^1.10.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: most_custom_lints
 description: Lints rules and corresponding annotations used by Dart/Flutter team at MOST.
-version: 0.0.3
+version: 0.0.4
 repository: https://github.com/MOST-Innovation-Labs/most_custom_lints
 
 environment:
@@ -11,7 +11,7 @@ dependencies:
   custom_lint: ^0.6.0
   custom_lint_builder: ^0.6.0
 
-  analyzer: ">=6.0.0 <6.8.0"
+  analyzer: ">=6.8.0 <7.0.0"
   analyzer_plugin: ^0.11.0
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: most_custom_lints
 description: Lints rules and corresponding annotations used by Dart/Flutter team at MOST.
-version: 0.0.2
+version: 0.0.3
 repository: https://github.com/MOST-Innovation-Labs/most_custom_lints
 
 environment:


### PR DESCRIPTION
Because of the most recent `package:analyzer@6.8.0` and `dart@3.5.0`, we need 2 releases: one for the old Dart SDK constraints, and the other - for the new Dart SDK version.